### PR TITLE
Fix: Eslint rules - React prop types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,8 +13,9 @@
     "ecmaVersion": 2021,
     "sourceType": "module"
   },
-  "rules": { 
+  "rules": {
     "react/react-in-jsx-scope": "off",
-    "@typescript-eslint/no-require-imports": "off" 
+    "react/prop-types": "off",
+    "@typescript-eslint/no-require-imports": "off"
   }
 }


### PR DESCRIPTION
Added a rule to the Eslint configuration to disable props validation via React